### PR TITLE
Separate FFmpeg operations from Docker containerization post

### DIFF
--- a/source/_posts/remote-docker-engine-server-ssh.md
+++ b/source/_posts/remote-docker-engine-server-ssh.md
@@ -4,6 +4,8 @@ tags:
   - Docker
   - SSH
   - Ubuntu
+  - WSL
+  - Networking
 abbrlink: 8f9620b4
 date: 2025-12-07 12:38:36
 ---
@@ -25,19 +27,20 @@ There appears to be lots of screen recordings that occupy gigabytes of storage s
 
 Counter-intuitively, there's actually no need to install or run Docker Desktop app on either the client or server side, as long as the **Docker daemon** is ready on the server host and **Docker CLI** is present on the client side, saving lots of confusion, time and effort on the unnecessary desktop app settings.
 
-Either **Docker daemon** and **Docker CLI** can be installed on the common *nix OS or distros including MacOS. If on Windows, **Windows Subsystem Linux (WSL)** will be helpful to prepare the runtime environment without the need to reinstall the entire OS or run a virtual machine, by enabling the certain optional feature instead.
+Either **Docker daemon** and **Docker CLI** can be installed on the common \*nix OS or distros including MacOS. If on Windows, **Windows Subsystem Linux (WSL)** will be helpful to prepare the runtime environment without the need to reinstall the entire OS or run a virtual machine, by enabling the certain optional feature instead.
 
 ## Server-side setup in Linux/WSL distro of Ubuntu (as an example)
 
 - Package sources
 
   Common practice to refresh the list of available packages and their versions:
+
   ```bash
   sudo apt update
   ```
-  
+
   Additionally, set up Docker's apt repository using Docker's official GPG key and Apt sources (recommended; see also [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/)).
-  
+
   ```bash
   # Add Docker's official GPG key:
   sudo apt update
@@ -45,7 +48,7 @@ Either **Docker daemon** and **Docker CLI** can be installed on the common *nix 
   sudo install -m 0755 -d /etc/apt/keyrings
   sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
   sudo chmod a+r /etc/apt/keyrings/docker.asc
-  
+
   # Add the repository to Apt sources:
   sudo tee /etc/apt/sources.list.d/docker.sources <<EOF
   Types: deb
@@ -54,13 +57,14 @@ Either **Docker daemon** and **Docker CLI** can be installed on the common *nix 
   Components: stable
   Signed-By: /etc/apt/keyrings/docker.asc
   EOF
-  
+
   sudo apt update
   ```
 
 - Where is `ifconfig`?
 
   After updating, install the `net-tools` package, which contains `ifconfig`, using this command:
+
   ```bash
   sudo apt install net-tools
   ```
@@ -70,15 +74,17 @@ Either **Docker daemon** and **Docker CLI** can be installed on the common *nix 
   ```bash
   sudo apt install openssh-server ssh-askpass ufw
   ```
-  
+
   Enable, Start and check SSH Service:
+
   ```bash
   sudo systemctl enable ssh
   sudo systemctl start ssh
   sudo systemctl status ssh
   ```
-  
+
   Adjust Firewall (using UFW):
+
   ```bash
   sudo ufw allow ssh
   ```
@@ -88,13 +94,15 @@ Either **Docker daemon** and **Docker CLI** can be installed on the common *nix 
   ```bash
   sudo apt install docker-ce docker-ce-cli containerd.io
   ```
-  
+
   The Docker service starts automatically after installation. To verify that Docker is running, use:
+
   ```bash
   sudo systemctl status docker
   ```
-  
+
   Verify that the installation is successful by running the hello-world image (expecting some human-readable self-explanatory outputs):
+
   ```
   sudo docker run hello-world
   ```
@@ -102,6 +110,7 @@ Either **Docker daemon** and **Docker CLI** can be installed on the common *nix 
 - More usages about Docker daemon ([read more](https://docs.docker.com/engine/daemon/))
 
   Test Docker daemon connection in a debug mode:
+
   ```
   dockerd --debug
     [--tls=true \]
@@ -109,18 +118,18 @@ Either **Docker daemon** and **Docker CLI** can be installed on the common *nix 
     [--tlskey=/var/docker/serverkey.pem \]
     [--host tcp://192.168.59.3:2376]
   ```
-  
+
   By default the daemon stores data in:
-  
-    - `/var/lib/docker` on Linux
-    - `C:\ProgramData\docker` on Windows
- 
+
+  - `/var/lib/docker` on Linux
+  - `C:\ProgramData\docker` on Windows
 
 ## Cliend-side setup ([reference](https://docs.docker.com/engine/security/protect-access/))
 
 Docker CLI needs to be installed on the client side as well, same as above.
 
 Create a Docker context to specify a non-local Docker host:
+
 ```bash
 docker context create \
     --docker host=ssh://docker-user@host1.example.com \
@@ -129,11 +138,13 @@ docker context create \
 ```
 
 The context doesn't take effect immediately upon creation. The next step is to inform the Docker CLI to use it, and to connect to the remote engine:
+
 ```bash
 docker context use my-remote-engine
 ```
 
 Quickly test if the context works out:
+
 ```bash
 docker info
 ```
@@ -142,10 +153,11 @@ docker info
 
 ## Additional SSH usages
 
-  - Executing a simple command:
-  ```bash
-  ssh user@example.com "ls -l /home/user"
-  ```
+- Executing a simple command:
+
+```bash
+ssh user@example.com "ls -l /home/user"
+```
 
 ## Windows environment setup (skip this if not using Windows on a host)
 
@@ -162,7 +174,7 @@ What's more, the current versions of WSL are `2.x`, also referred to as `WSL2`. 
   ```
 
 - List the local distros installed
-  
+
   ```powershell
   wsl --list [--verbose]
   ```
@@ -183,13 +195,32 @@ What's more, the current versions of WSL are `2.x`, also referred to as `WSL2`. 
 
 - Stop a running WSL distro only without removing its filesystem
 
-  ```
+  As an example, it will make the changes to the `.wslconfig` file take effect:
+
+  ```powershell
   wsl --shutdown
   ```
 
 - Remove a WSL distro instance with its filesystem
-  ```
+
+  ```powershell
   wsl --unregister ubuntu
+  ```
+
+- Export a WSL distro to a file
+
+  It helps to create a backup (as `.tar` file by default) or relocate the distro to a different directory (shutdown recommended as above):
+
+  ```powershell
+  wsl --export <DistributionName> <Full path to .tar/.vhdx FileName> [--vhd]
+  ```
+
+- Import a file as a WSL distro
+
+  This allows to create a distro filesystem in a different directory other than before:
+
+  ```powershell
+  wsl --import <NewDistributionName> <InstallLocation> <Full path to .tar/.vhdx FileName>
   ```
 
 ### Network Configs on a Windows host
@@ -197,6 +228,7 @@ What's more, the current versions of WSL are `2.x`, also referred to as `WSL2`. 
 - Allow for incoming `ping` requests
 
   Add this rule to the firewall via Powershell with administrator permissions to resolve the timeout error of `ping`:
+
   ```powershell
   New-NetFirewallRule -Name "Ping" -Protocol ICMPv4 -Direction Inbound -Action Allow
   ```
@@ -204,11 +236,13 @@ What's more, the current versions of WSL are `2.x`, also referred to as `WSL2`. 
 - Allow for incoming SSH requests
 
   This is to enable the built-in firewall rule for the OpenSSH Server:
+
   ```
   Enable-NetFirewallRule -DisplayGroup "OpenSSH Server"
   ```
 
   Alternatively, manually create a new inbound firewall rule:
+
   ```
   New-NetFirewallRule -DisplayName "Allow SSH Inbound" -Direction Inbound -Protocol TCP -LocalPort 22 -Action Allow -Profile Any
   ```
@@ -216,13 +250,13 @@ What's more, the current versions of WSL are `2.x`, also referred to as `WSL2`. 
 - Set up Port Forwarding on Windows host
 
   This is to add a port proxy rule to forward a local port 22 on Windows host to the WSL SSH server port 22 in WSL:
-  
+
   ```powershell
   netsh interface portproxy add v4tov4 listenport=22 listenaddress=0.0.0.0 connectport=22 connectaddress=<wsl-ip>
   ```
 
 - Test connecting to WSL server via SSH from another device
-  
+
   ```powershell
   ssh username@host_ip [-p 22]
   ```
@@ -230,6 +264,7 @@ What's more, the current versions of WSL are `2.x`, also referred to as `WSL2`. 
 - Alternative: SSH Tunnels from Windows to a Remote Host via WSL (SSH Tunneling)
 
   This option hasn't been tested and verified yet:
+
   ```powershell
   ssh -L <local-port>:localhost:<remote-port> <remote-host>
   ```
@@ -245,12 +280,14 @@ What's more, the current versions of WSL are `2.x`, also referred to as `WSL2`. 
   Navigate to the Windows user profile directory: `%userprofile%` (e.g., `C:\Users\YourUsername`).
   Create a file named `.wslconfig` if it doesn't exist.
   Open the file and add the following lines:
+
   ```ini
   [wsl2]
   ; Sets the time in seconds that a WSL 2 distro can be idle before it is terminated.
   ; To disable the timeout, set this to -1.
   vmIdleTimeout=-1
   ```
+
 ## Known Issue of OpenSSH / Docker
 
 - `docker stderr=ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or director`
@@ -258,6 +295,7 @@ What's more, the current versions of WSL are `2.x`, also referred to as `WSL2`. 
   [External reference](https://stackoverflow.com/questions/76107890/bitbucket-pipeline-fails-with-ssh-error-ssh-askpass-exec-usr-bin-ssh-askpass)
 
   Install the ssh-askpass package:
+
   ```bash
   sudo apt install [-y] ssh-askpass
   ```

--- a/source/_posts/remote-docker-engine-server-ssh.md
+++ b/source/_posts/remote-docker-engine-server-ssh.md
@@ -29,6 +29,8 @@ Counter-intuitively, there's actually no need to install or run Docker Desktop a
 
 Either **Docker daemon** and **Docker CLI** can be installed on the common \*nix OS or distros including MacOS. If on Windows, **Windows Subsystem Linux (WSL)** will be helpful to prepare the runtime environment without the need to reinstall the entire OS or run a virtual machine, by enabling the certain optional feature instead.
 
+Even if Docker Desktop is installed on Windows, the runtime environment has to be held in WSL anyway.
+
 ## Server-side setup in Linux/WSL distro of Ubuntu (as an example)
 
 - Package sources
@@ -120,7 +122,6 @@ Either **Docker daemon** and **Docker CLI** can be installed on the common \*nix
   ```
 
   By default the daemon stores data in:
-
   - `/var/lib/docker` on Linux
   - `C:\ProgramData\docker` on Windows
 
@@ -299,3 +300,13 @@ What's more, the current versions of WSL are `2.x`, also referred to as `WSL2`. 
   ```bash
   sudo apt install [-y] ssh-askpass
   ```
+
+- "Connection timeout" even with SSH connection tested okay
+
+Check `docker context` on both host and client sides:
+
+```
+docker context ls
+docker context show
+docker context use [context name]
+```

--- a/source/_posts/remote-ffmpeg-server.md
+++ b/source/_posts/remote-ffmpeg-server.md
@@ -1,0 +1,81 @@
+---
+title: Running FFmpeg on a Remote Server
+tags:
+  - SSH
+  - FFmpeg
+abbrlink: e05bb15e
+date: 2025-12-17 16:51:02
+---
+
+# Background
+
+See also [remote Docker server via SSH](posts/8f9620b4/).
+
+# Basics
+
+[Reference: FFmpeg syntax and examples](https://ffmpeg-api.com/learn/ffmpeg/guide/syntax-and-examples)
+
+## Streaming
+
+### Streaming capability
+
+Be aware that not all the video container formats allow for streaming. Compared to the commonly used `.mp4`, effective streamable video container (muxer) names for use with FFmpeg are `Matroska` (`.mkv`), `MPEG-TS` (`.m2ts` preferred over `.ts` to be distinguished against TypeScript) and so on.
+
+<iframe width="545" height="320" src="https://www.youtube.com/embed/-ssOzR0qSe4" title="What is Video Formats, Container, Codecs | Explained!" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+If the proper format option is missing, an error may occur from FFmpeg as:
+
+```
+Unable to choose an output format for 'pipe:'; use a standard extension for the filename or specify the format manually.
+```
+
+### Preview an **outbound** stream in real-time replay
+
+```bash
+ffmpeg -i [input_source] -f [format] - | ffplay -f [format] -
+```
+
+### Pipe and stream videos over SSH **outbound** to a remote ffmpeg process
+
+Note: `-y` option is to skip any keyboard input prompt (in case of overriding an existing output file) to avoid the "broken pipe" error.
+
+```bash
+ffmpeg -i [input_source] -f [format] - | ssh [remote_user]@[remote_host] "ffmpeg -y -i pipe:0 [options] [output]"
+```
+
+### Preview an **inbound** stream in real-time replay
+
+```bash
+ssh [remote_user]@[remote_host] "ffmpeg -i [input_source] -f [format] -" | ffplay -f [format] -
+```
+
+### Pipe and stream videos over SSH **inbound** from a remote ffmpeg process
+
+```bash
+ssh [remote_user]@[remote_host] "ffmpeg -i [input_source] -f [format] pipe:1" | cat > output_file
+```
+
+## Performance/Quality Tuning
+
+### Nvidia GPU-accelerated video processing
+
+[Reference 1](https://stackoverflow.com/questions/44510765/gpu-accelerated-video-processing-with-ffmpeg)  
+[Reference 2](https://unix.stackexchange.com/questions/794394/how-to-make-ffmpeg-use-gpu-mostly-for-reducing-file-sizes)
+
+CUDA
+
+```
+ffmpeg -i [input] -hwaccel cuda [output]
+```
+
+CUVID
+
+```
+ffmpeg -i [input] -c:v h264_cuvid [output]
+```
+
+Full hardware transcode with NVDEC and NVENC
+
+```
+ffmpeg -hwaccel cuda -hwaccel_output_format cuda -i [input] -c:v h264_nvenc [output]
+```

--- a/source/_posts/remote-ffmpeg-server.md
+++ b/source/_posts/remote-ffmpeg-server.md
@@ -15,6 +15,14 @@ See also [remote Docker server via SSH](posts/8f9620b4/).
 
 [Reference: FFmpeg syntax and examples](https://ffmpeg-api.com/learn/ffmpeg/guide/syntax-and-examples)
 
+## Quick reference
+
+Combining video and audio streams from different sources (assuming stream #0 for video and stream #1 for audio):
+
+```bash
+ffmpeg -i [input_source_0] -i [input_source_1] -c copy -map 0:v:0 -map 1:a:0 [output]
+```
+
 ## Streaming
 
 ### Streaming capability
@@ -61,6 +69,7 @@ ssh [remote_user]@[remote_host] "ffmpeg -i [input_source] -f [format] pipe:1" | 
 
 [Reference 1](https://stackoverflow.com/questions/44510765/gpu-accelerated-video-processing-with-ffmpeg)  
 [Reference 2](https://unix.stackexchange.com/questions/794394/how-to-make-ffmpeg-use-gpu-mostly-for-reducing-file-sizes)
+[Using FFmpeg with NVIDIA GPU Hardware Acceleration](https://docs.nvidia.com/video-technologies/video-codec-sdk/13.0/ffmpeg-with-nvidia-gpu/index.html)
 
 CUDA
 
@@ -79,3 +88,7 @@ Full hardware transcode with NVDEC and NVENC
 ```
 ffmpeg -hwaccel cuda -hwaccel_output_format cuda -i [input] -c:v h264_nvenc [output]
 ```
+
+## Further extension - batch operation
+
+[Batch video processing](https://img.ly/blog/building-a-production-ready-batch-video-processing-server-with-ffmpeg/)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes (new post and edits to existing post) with no runtime or production code impact.
> 
> **Overview**
> **Refactors and expands documentation around remote video processing.** The Docker-over-SSH post is retitled and broadened with WSL/networking focus, adds pre-start considerations, clearer server setup steps (SSH service enablement, UFW, Docker repo/service verification), and a new client-side section for using `docker context` over `ssh://`.
> 
> Adds a new `remote-ffmpeg-server.md` post that documents running/streaming FFmpeg remotely over SSH (pipe/ffplay examples) plus basic performance notes (NVIDIA GPU acceleration), linking back to the Docker/SSH post. The Docker post also gains troubleshooting notes for WSL idle timeout and `ssh-askpass`/context-related connection issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01b024e18eb59c6b3f0e267d16561a3dec2a124f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->